### PR TITLE
Set max-age to 24 hours for downloaded taxonomy file

### DIFF
--- a/src/LukeSnowden/GoogleShoppingFeed/Feed.php
+++ b/src/LukeSnowden/GoogleShoppingFeed/Feed.php
@@ -186,7 +186,7 @@ class Feed {
 	public function categories() {
 		$cache = new Cache;
 		$cache->setCacheDirectory($this->cacheDir);
-		$data = $cache->getOrCreate('google-feed-taxonomy.txt', array( 'max-age' => '860400' ), function() {
+		$data = $cache->getOrCreate('google-feed-taxonomy.txt', array( 'max-age' => '86400' ), function() {
 		    return file_get_contents("http://www.google.com/basepages/producttype/taxonomy.en-GB.txt");
 		});
 		return explode( "\n", trim($data) );


### PR DESCRIPTION
Actually the max-cache is set to 239 hours

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lukesnowden/google-shopping-feed/4)
<!-- Reviewable:end -->
