### PR TITLE
removed static calls from Item class allowing for non-static usage of…

### DIFF
--- a/src/LukeSnowden/GoogleShoppingFeed/Feed.php
+++ b/src/LukeSnowden/GoogleShoppingFeed/Feed.php
@@ -130,7 +130,7 @@ class Feed
     public function createItem()
     {
         $this->channel();
-        $item = new Item;
+        $item = new Item($this);
         $index = 'index_' . md5(microtime());
         $this->items[$index] = $item;
         $item->setIndex($index);

--- a/src/LukeSnowden/GoogleShoppingFeed/Item.php
+++ b/src/LukeSnowden/GoogleShoppingFeed/Item.php
@@ -62,10 +62,20 @@ class Item
     private $index = null;
 
     /**
+     * @var Feed
+     */
+    private $googleShoppingFeed = null;
+
+    /**
      * [$namespace - (g:) namespace definition]
      * @var string
      */
     protected $namespace = 'http://base.google.com/ns/1.0';
+
+    public function __construct($googleShoppingFeed)
+    {
+        $this->googleShoppingFeed = $googleShoppingFeed;
+    }
 
     /**
      * @param $id
@@ -105,7 +115,7 @@ class Item
         $price = (float) preg_replace( "/^([0-9]+\.?[0-9]*)(\s[A-Z]{3})$/", "$1", $price );
         $node = new Node('price');
         $price = number_format($price, 2, '.', '');
-        $code = GoogleShopping::getIso4217CountryCode();
+        $code = $this->googleShoppingFeed->getIso4217CountryCode();
         $this->nodes['price'] = $node->value( $price . " {$code}" )->_namespace($this->namespace);
     }
 
@@ -118,7 +128,7 @@ class Item
         $salePrice = (float) preg_replace( "/^([0-9]+\.?[0-9]*)(\s[A-Z]{3})$/", "$1", $salePrice );
         $node = new Node('sale_price');
         $salePrice = number_format($salePrice, 2, '.', '');
-        $code = GoogleShopping::getIso4217CountryCode();
+        $code = $this->googleShoppingFeed->getIso4217CountryCode();
         $this->nodes['sale_price'] = $node->value( $salePrice . " {$code}" )->_namespace($this->namespace);
     }
 
@@ -402,7 +412,7 @@ class Item
      */
     public function delete()
     {
-        GoogleShopping::removeItemByIndex($this->index);
+        $this->googleShoppingFeed->removeItemByIndex($this->index);
     }
 
     /**
@@ -426,7 +436,7 @@ class Item
     {
        $groupIdentifiers = $this->getGroupIdentifier();
         /** @var Item $item */
-        $item = GoogleShopping::createItem();
+        $item = $this->googleShoppingFeed->createItem();
         $this->item_group_id( $groupIdentifiers );
         foreach ($this->nodes as $node) {
             if (is_array($node)) {


### PR DESCRIPTION
Allowing for non-static usage of Feed, e.g.:


use LukeSnowden\GoogleShoppingFeed\Feed;

$feed = new Feed();
$feed->title('Test Feed');
$feed->link('http://example.com/');
$feed->description('Our Google Shopping Feed');

foreach( $products as $product ) {

	$item = $feed->createItem();
	$item->id($id);
	$item->title($title);
	$item->price($price);
	$item->mpn($SKU);
	$item->sale_price($salePrice);
	$item->link($link);
	$item->image_link($imageLink);
	...
	...

	/** create a variant */
	$variant = $item->variant();
	$variant->size($variant::LARGE);
	$variant->color('Red');

	/**
	 * One thing to note, if creating variants, delete the initial object after you've done,
	 * Google no longer needs it!
	 *
	 * $item->delete();
	 *
	 */

}

// boolean value indicates output to browser
$feed->asRss(true);


Everything else will still work as before ;-)