### PR TITLE
Fixing clone it method, when using custom method to create a node

### DIFF
--- a/src/LukeSnowden/GoogleShoppingFeed/Item.php
+++ b/src/LukeSnowden/GoogleShoppingFeed/Item.php
@@ -444,7 +444,7 @@ class Item
      */
     public function cloneIt()
     {
-       $groupIdentifiers = $this->getGroupIdentifier();
+        $groupIdentifiers = $this->getGroupIdentifier();
         /** @var Item $item */
         $item = $this->googleShoppingFeed->createItem();
         $this->item_group_id( $groupIdentifiers );
@@ -462,7 +462,14 @@ class Item
                     }
                 }
             } elseif ($node->get('name') !== 'shipping') {
-                $item->{$node->get('name')}($node->get('value'));
+                if (method_exists($item->{$node->get('name')})) {
+                    $item->{$node->get('name')}($node->get('value'));
+                    return $item;
+                }
+
+                if (!method_exists($item->{$node->get('name')})) {
+                    $item->custom($node->get('name'), ($node->get('value')));
+                }
             }
         }
         return $item;


### PR DESCRIPTION
I've noticed that when I try to clone item that was using custom method during creation, we get an error about not existing method. 