### PR TITLE
fixing cloneit method, so it actually uses exising method instead of …

### DIFF
--- a/src/LukeSnowden/GoogleShoppingFeed/Item.php
+++ b/src/LukeSnowden/GoogleShoppingFeed/Item.php
@@ -462,12 +462,12 @@ class Item
                     }
                 }
             } elseif ($node->get('name') !== 'shipping') {
-                if (method_exists($item->{$node->get('name')})) {
+                if (method_exists($item, $node->get('name'))) {
                     $item->{$node->get('name')}($node->get('value'));
-                    return $item;
+                    continue;
                 }
 
-                if (!method_exists($item->{$node->get('name')})) {
+                if (!method_exists($item, $node->get('name'))) {
                     $item->custom($node->get('name'), ($node->get('value')));
                 }
             }


### PR DESCRIPTION
Sorry, my bad. The way method_exists was used in previous commit, was causing everything to go through "custom" method. Now it should actually use existing method, I've tested it on my feed first and it seems fine, I rushed on the previous one.