### PR TITLE
Ability to output in different formats

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,24 +1,5 @@
 {
-    "name": "lukesnowden/google-shopping-feed",
+    "name": "5zymon/google-shopping-feed",
     "description": "Google Shopping Feed API",
-    "homepage": "https://github.com/lukesnowden/google-shopping-feed",
-    "license": "MIT",
-    "keywords" : ["Google","Shopping","Google Shopping Feed","Feed","API"],
-    "authors": [
-        {
-            "name": "Luke Snowden",
-            "email": "luke@sno.wden.co.uk"
-        }
-    ],
-    "require": {
-        "php": ">=7.0.10",
-        "gregwar/cache": "1.0.*",
-        "league/csv": "9.*"
-    },
-    "autoload": {
-        "psr-0": {
-            "LukeSnowden\\GoogleShoppingFeed": "src/"
-        }
-    },
-    "minimum-stability": "dev"
+    "homepage": "https://github.com/lukesnowden/google-shopping-feed"
 }

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,9 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0",
-        "gregwar/cache": "1.0.*"
+        "php": ">=7.0.10",
+        "gregwar/cache": "1.0.*",
+        "league/csv": "9.*"
     },
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,24 @@
 {
     "name": "5zymon/google-shopping-feed",
     "description": "Google Shopping Feed API",
-    "homepage": "https://github.com/lukesnowden/google-shopping-feed"
+    "homepage": "https://github.com/lukesnowden/google-shopping-feed",
+    "license": "MIT",
+    "keywords" : ["Google","Shopping","Google Shopping Feed","Feed","API"],
+    "authors": [
+        {
+            "name": "Luke Snowden",
+            "email": "luke@sno.wden.co.uk"
+        }
+    ],
+    "require": {
+        "php": ">=7.0.10",
+        "gregwar/cache": "1.0.*",
+        "league/csv": "9.*"
+    },
+    "autoload": {
+        "psr-0": {
+            "LukeSnowden\\GoogleShoppingFeed": "src/"
+        }
+    },
+    "minimum-stability": "dev"
 }

--- a/src/LukeSnowden/GoogleShoppingFeed/Containers/GoogleShopping.php
+++ b/src/LukeSnowden/GoogleShoppingFeed/Containers/GoogleShopping.php
@@ -1,8 +1,12 @@
 <?php
 
+
+
 namespace LukeSnowden\GoogleShoppingFeed\Containers;
 
-use LukeSnowden\GoogleShoppingFeed\Feed;
+use LukeSnowden\GoogleShoppingFeed\Formats;
+use LukeSnowden\GoogleShoppingFeed\Formats\Csv;
+use LukeSnowden\GoogleShoppingFeed\Formats\Xml;
 
 class GoogleShopping
 {
@@ -18,8 +22,12 @@ class GoogleShopping
      */
     public static function container()
     {
-        if (is_null(static::$container)) {
-            static::$container = new Feed;
+        if (is_null(static::$container) || static::$container == Formats::XML) {
+            static::$container = new Xml;
+        }
+
+        if (static::$container == Formats::CSV) {
+            static::$container = new Csv();
         }
 
         return static::$container;

--- a/src/LukeSnowden/GoogleShoppingFeed/FeedAbstract.php
+++ b/src/LukeSnowden/GoogleShoppingFeed/FeedAbstract.php
@@ -1,0 +1,251 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: szymon
+ * Date: 3/15/19
+ * Time: 4:03 AM
+ */
+
+namespace LukeSnowden\GoogleShoppingFeed;
+
+
+abstract class FeedAbstract implements FeedInterface
+{
+
+    /**
+     * Define Google Namespace url
+     * @var string
+     */
+    protected $namespace = 'http://base.google.com/ns/1.0';
+
+    /**
+     * @var string
+     */
+    protected $version = '2.0';
+
+    /**
+     * @var string
+     */
+    protected $iso4217CountryCode = 'GBP';
+
+    /**
+     * Stores the list of items for the feed
+     * @var Item[]
+     */
+    protected $items = array();
+
+    /**
+     * @var bool
+     */
+    protected $channelCreated = false;
+
+    /**
+     * The base for the feed
+     * @var SimpleXMLElement
+     */
+    protected $feed = null;
+
+    /**
+     * @var string
+     */
+    protected $title = '';
+
+    /**
+     * @var string
+     */
+    protected $cacheDir = 'cache';
+
+    /**
+     * @var string
+     */
+    protected $description = '';
+
+    /**
+     * @var string
+     */
+    protected $link = '';
+
+
+
+    /**
+     * @param string $title
+     */
+    public function title($title)
+    {
+        $this->title = (string)$title;
+    }
+
+    /**
+     * @param string $description
+     */
+    public function description($description)
+    {
+        $this->description = (string)$description;
+    }
+
+    /**
+     * @param string $link
+     */
+    public function link($link)
+    {
+        $this->link = (string)$link;
+    }
+
+    /**
+     * @param $code
+     */
+    public function setIso4217CountryCode( $code )
+    {
+        $this->iso4217CountryCode = $code;
+    }
+
+    /**
+     * @return string
+     */
+    public function getIso4217CountryCode()
+    {
+        return $this->iso4217CountryCode;
+    }
+
+
+    /**
+     * @param string $group
+     * @return bool|string
+     */
+    public function isVariant($group)
+    {
+        if (preg_match("#^\s*colou?rs?\s*$#is", trim($group))) {
+            return 'color';
+        }
+        if (preg_match("#^\s*sizes?\s*$#is", trim($group))) {
+            return 'size';
+        }
+        if (preg_match("#^\s*materials?\s*$#is", trim($group))) {
+            return 'material';
+        }
+        return false;
+    }
+
+    public function removeItemByIndex($index){
+        if(array_key_exists($index, $this->items)) {
+            unset($this->items[$index]);
+        }
+    }
+
+    /**
+     * @param mixed $value
+     * @return mixed
+     */
+    public function standardiseSizeVarient($value)
+    {
+        return $value;
+    }
+
+    /**
+     * @param mixed $value
+     * @return mixed
+     */
+    public function standardiseColourVarient($value)
+    {
+        return $value;
+    }
+
+    /**
+     * Retrieve Google product categories from internet and cache the result
+     * @param string $languageISO639
+     * @return array
+     */
+    public function categories($languageISO639 = 'gb')
+    {
+        //map two letter language to culture
+        $languageMap = array(
+            'au' => 'en-AU',
+            'br' => 'pt-BR',
+            'cn' => 'zh-CN',
+            'cz' => 'cs-CZ',
+            'de' => 'de-DE',
+            'dk' => 'da-DK',
+            'es' => 'es-ES',
+            'fr' => 'fr-FR',
+            'gb' => 'en-GB',
+            'it' => 'it-IT',
+            'jp' => 'ja-JP',
+            'nl' => 'nl-NL',
+            'no' => 'no-NO',
+            'pl' => 'pl-PL',
+            'ru' => 'ru-RU',
+            'sw' => 'sv-SE',
+            'tr' => 'tr-TR',
+            'us' => 'en-US'
+        );
+        //set default language to gb for backward compatibility
+        $languageCulture = $languageMap['gb'];
+        if (array_key_exists($languageISO639, $languageMap)) {
+            $languageCulture = $languageMap[$languageISO639];
+        }
+
+        $cache = new Cache;
+        $cache->setCacheDirectory($this->cacheDir);
+        $data = $cache->getOrCreate('google-feed-taxonomy.'.$languageISO639.'.txt', array('max-age' => '86400'),
+            function () use ($languageCulture) {
+                return file_get_contents("http://www.google.com/basepages/producttype/taxonomy." . $languageCulture . ".txt");
+            }
+        );
+
+        return explode("\n", trim($data));
+    }
+
+    /**
+     * Build an HTML select containing Google taxonomy categories
+     * @param string $selected
+     * @param string $languageISO639
+     * @return string
+     */
+    public function categoriesAsSelect($selected = '', $languageISO639 = 'gb')
+    {
+        $categories = $this->categories($languageISO639);
+        unset($categories[0]);
+        $select = '<select name="google_category">';
+        $select .= '<option value="">Please select a Google Category</option>';
+        foreach ($categories as $category) {
+            $select .= '<option ' . ($category == $selected ? 'selected' : '') . ' name="' . $category . '">' . $category . '</option>';
+        }
+        $select .= '</select>';
+        return $select;
+    }
+
+    /**
+     * @param string $languageISO639
+     * @return array
+     */
+    public function categoriesAsNameAssociativeArray( $languageISO639 = 'gb' )
+    {
+        $categories = $this->categories($languageISO639);
+        unset($categories[0]);
+        $return = [];
+        foreach( $categories as $key => $value ) {
+            $return[$value] = $value;
+        }
+        return $return;
+    }
+
+    /**
+     * Remove last inserted item
+     */
+    public function removeLastItem()
+    {
+        array_pop($this->items);
+    }
+
+    public function createItem()
+    {
+        // TODO: Implement createItem() method.
+    }
+
+    public function asRss($output = false)
+    {
+        // TODO: Implement asRss() method.
+    }
+
+
+}

--- a/src/LukeSnowden/GoogleShoppingFeed/FeedInterface.php
+++ b/src/LukeSnowden/GoogleShoppingFeed/FeedInterface.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: szymon
+ * Date: 3/14/19
+ * Time: 8:26 AM
+ */
+
+namespace LukeSnowden\GoogleShoppingFeed;
+
+interface FeedInterface
+{
+    /**
+     * @param string $title
+     */
+    public function title($title);
+
+    /**
+     * @param string $description
+     */
+    public function description($description);
+
+    /**
+     * @param string $link
+     */
+    public function link($link);
+
+    /**
+     * @param $code
+     */
+    public function setIso4217CountryCode($code);
+
+    /**
+     * @return string
+     */
+    public function getIso4217CountryCode();
+
+    /**
+     * @return Item
+     */
+    public function createItem();
+
+    /**
+     * @param int $index
+     */
+    public function removeItemByIndex($index);
+
+    /**
+     * @param string $group
+     * @return bool|string
+     */
+    public function isVariant($group);
+
+    /**
+     * Retrieve Google product categories from internet and cache the result
+     * @param string $languageISO639
+     * @return array
+     */
+    public function categories($languageISO639 = 'gb');
+
+    /**
+     * Build an HTML select containing Google taxonomy categories
+     * @param string $selected
+     * @param string $languageISO639
+     * @return string
+     */
+    public function categoriesAsSelect($selected = '', $languageISO639 = 'gb');
+
+    /**
+     * @param string $languageISO639
+     * @return array
+     */
+    public function categoriesAsNameAssociativeArray($languageISO639 = 'gb');
+
+    /**
+     * Generate RSS feed
+     * @param bool $output
+     * @return string
+     */
+    public function asRss($output = false);
+
+    /**
+     * Remove last inserted item
+     */
+    public function removeLastItem();
+}

--- a/src/LukeSnowden/GoogleShoppingFeed/Formats.php
+++ b/src/LukeSnowden/GoogleShoppingFeed/Formats.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: szymon
+ * Date: 3/15/19
+ * Time: 4:15 AM
+ */
+
+namespace LukeSnowden\GoogleShoppingFeed;
+
+
+class Formats
+{
+    const CSV = 'csv';
+    const XML = 'xml';
+}

--- a/src/LukeSnowden/GoogleShoppingFeed/Formats/Csv.php
+++ b/src/LukeSnowden/GoogleShoppingFeed/Formats/Csv.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: szymon
+ * Date: 3/14/19
+ * Time: 8:33 AM
+ */
+
+namespace LukeSnowden\GoogleShoppingFeed\Formats;
+
+use League\Csv\Writer;
+use LukeSnowden\GoogleShoppingFeed;
+use LukeSnowden\GoogleShoppingFeed\FeedInterface;
+use LukeSnowden\GoogleShoppingFeed\Item;
+use LukeSnowden\GoogleShoppingFeed\FeedAbstract;
+
+class Csv extends FeedAbstract
+{
+
+
+    public function __construct()
+    {
+        $this->feed = Writer::createFromFileObject(new \SplTempFileObject());
+    }
+
+    public function createItem(){
+        $item = new Item($this);
+        $index = 'index_' . md5(microtime());
+        $this->items[$index] = $item;
+        $item->setIndex($index);
+        return $item;
+    }
+
+    public function asRss($output = false)
+    {
+        if (ob_get_contents()) ob_end_clean();
+        $this->addItemsToFeed();
+        $data = $this->feed->getContent();
+        if ($output) {
+            header('Content-Type: application/xml; charset=utf-8');
+            die($data);
+        }
+        return $data;
+    }
+
+    /**
+     * Adds items to feed
+     */
+    private function addItemsToFeed()
+    {
+        $this->insertHeaderRow();
+        $data = array();
+        foreach ($this->items as $item) {
+            $row = array();
+            /** @var GoogleShoppingFeed\Node $itemNode */
+            foreach ($item->nodes() as $itemNode) {
+                $row[] = $itemNode->get('value');
+            }
+            $data[] = $row;
+        }
+
+        $this->feed->insertAll($data);
+    }
+
+    private function insertHeaderRow()
+    {
+        if (count($this->items) > 0) {
+            $item = current($this->items);
+            $headerRow = array();
+            foreach ($item->nodes() as $key=>$node) {
+                $headerRow[] = $key;
+            }
+        }
+
+        $this->feed->insertOne($headerRow);
+    }
+
+}

--- a/src/LukeSnowden/GoogleShoppingFeed/Formats/Xml.php
+++ b/src/LukeSnowden/GoogleShoppingFeed/Formats/Xml.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace LukeSnowden\GoogleShoppingFeed\Formats;
+
+use SimpleXMLElement;
+use LukeSnowden\GoogleShoppingFeed\Item;
+use LukeSnowden\GoogleShoppingFeed;
+use LukeSnowden\GoogleShoppingFeed\FeedInterface;
+use LukeSnowden\GoogleShoppingFeed\FeedAbstract;
+use Gregwar\Cache\Cache;
+
+class Xml extends FeedAbstract
+{
+
+    /**
+     * Feed constructor
+     */
+    public function __construct()
+    {
+        $this->feed = new SimpleXMLElement('<rss xmlns:g="' . $this->namespace . '" version="' . $this->version . '"></rss>');
+    }
+
+    /**
+     * [channel description]
+     */
+    private function channel()
+    {
+        if (! $this->channelCreated) {
+            $channel = $this->feed->addChild('channel');
+            $channel->addChild('title', htmlspecialchars($this->title));
+            $channel->addChild('link', htmlspecialchars($this->link));
+            $channel->addChild('description', htmlspecialchars($this->description));
+            $this->channelCreated = true;
+        }
+    }
+
+    /**
+     * @return Item
+     */
+    public function createItem()
+    {
+        $this->channel();
+        $item = new Item($this);
+        $index = 'index_' . md5(microtime());
+        $this->items[$index] = $item;
+        $item->setIndex($index);
+        return $item;
+    }
+
+    /**
+     * Adds items to feed
+     */
+    private function addItemsToFeed()
+    {
+        foreach ($this->items as $item) {
+            /** @var SimpleXMLElement $feedItemNode */
+            $feedItemNode = $this->feed->channel->addChild('item');
+            foreach ($item->nodes() as $itemNode) {
+                if (is_array($itemNode)) {
+                    foreach ($itemNode as $node) {
+                        $feedItemNode->addChild($node->get('name'), $node->get('value'), $node->get('_namespace'));
+                    }
+                } else {
+                    $itemNode->attachNodeTo($feedItemNode);
+                }
+            }
+        }
+    }
+
+
+    /**
+     * Generate RSS feed
+     * @param bool $output
+     * @return string
+     */
+    public function asRss($output = false)
+    {
+        if (ob_get_contents()) ob_end_clean();
+        $this->addItemsToFeed();
+        $data = html_entity_decode($this->feed->asXml());
+        if ($output) {
+            header('Content-Type: application/xml; charset=utf-8');
+            die($data);
+        }
+        return $data;
+    }
+
+
+}

--- a/src/LukeSnowden/GoogleShoppingFeed/Item.php
+++ b/src/LukeSnowden/GoogleShoppingFeed/Item.php
@@ -255,6 +255,24 @@ class Item
     }
 
     /**
+     * @param $multipack
+     */
+    public function multipack($multipack)
+    {
+        $node = new Node('multipack');
+        $this->nodes['multipack'] = $node->value($multipack)->_namespace($this->namespace);
+    }
+
+    /**
+     * @param $unitPricingMeasure
+     */
+    public function unitPricingMeasure($unitPricingMeasure)
+    {
+        $node = new Node('unit_​pricing_​measure');
+        $this->nodes['unit_​pricing_​measure'] = $node->value($unitPricingMeasure)->_namespace($this->namespace);
+    }
+
+    /**
      * @param $code
      * @param $service
      * @param $cost


### PR DESCRIPTION
This update is bigger in compare to the previous one, so you may want to take a longer look before merging :-).  

I needed output to CSV file so I modified google shopping container - which I think was prepared for functionality like this in future. I've separated feed class into formats classes one for XML and one for CSV. Core functionality stayed the same, I am using this library in other module and without making any changes in the module, it generates same XML output as before, so I assume all is good here I didn't break anything. But now when you enter 'csv' in the container, instead of null, you'll get CSV as an output. 

It also requires new lib league/csv, which requires php 7 so I had to move the require in composer.json up from php 5.3.0 (which isn't that bad anyway I think ;-)).

