### PR TITLE
fix - the description is wrong when the description length is over 5000 and it contains the multi-byte character

### DIFF
--- a/src/LukeSnowden/GoogleShoppingFeed/Item.php
+++ b/src/LukeSnowden/GoogleShoppingFeed/Item.php
@@ -143,13 +143,18 @@ class Item
 
     /**
      * @param $description
+     * @param string $encoding
      */
-    public function description($description)
+    public function description($description, string $encoding = '')
     {
+        if (empty($encoding)) {
+            $encoding = mb_internal_encoding();
+        }
+
         $description = preg_replace( "#<iframe[^>]+>[^<]?</iframe>#is", '', $description );
         $node = new Node('description');
         $description = $this->safeCharEncodeText($description);
-        $this->nodes['description'] = $node->value(substr($description, 0, 5000))->_namespace($this->namespace)->addCdata();
+        $this->nodes['description'] = $node->value(mb_substr($description, 0, 5000, $encoding))->_namespace($this->namespace)->addCdata();
     }
 
     /**


### PR DESCRIPTION
fix - the description is wrong when the description length is over 5000 and it contains the multi-byte character