### PR TITLE
Remove string typehint

### DIFF
--- a/src/LukeSnowden/GoogleShoppingFeed/Item.php
+++ b/src/LukeSnowden/GoogleShoppingFeed/Item.php
@@ -154,7 +154,7 @@ class Item
      * @param $description
      * @param string $encoding
      */
-    public function description($description, string $encoding = '')
+    public function description($description, $encoding = '')
     {
         if (empty($encoding)) {
             $encoding = mb_internal_encoding();


### PR DESCRIPTION
fixes issue: "Default value for parameters with a class type hint can only be NULL" with php < 7.0.
(alternately, the requirement for the package should be updated to php 7.0.