### PR TITLE
allow to add the mobile link

### DIFF
--- a/src/LukeSnowden/GoogleShoppingFeed/Item.php
+++ b/src/LukeSnowden/GoogleShoppingFeed/Item.php
@@ -109,6 +109,16 @@ class Item
     }
 
     /**
+     * @param $mobile_link
+     */
+    public function mobile_link($mobile_link)
+    {
+        $node = new Node('mobile_link');
+        $link = $this->safeCharEncodeURL($mobile_link);
+        $this->nodes['mobile_link'] = $node->value($mobile_link)->_namespace($this->namespace)->addCdata();
+    }
+
+    /**
      * @param $link
      */
     public function link($link)


### PR DESCRIPTION
When reading the feed's and sitemap google complains because there is no mobile link, this contribution allows to generate it.
https://support.google.com/merchants/answer/6324459